### PR TITLE
Fix CSV Parsing for Quoted Fields

### DIFF
--- a/src/utils/csv-utils.ts
+++ b/src/utils/csv-utils.ts
@@ -6,6 +6,7 @@ export interface CSVParseConfig {
     dynamicTyping: boolean;
     skipEmptyLines: boolean;
     delimiter?: string;
+    quoteChar?: string;
 }
 
 export class CSVUtils {
@@ -13,7 +14,8 @@ export class CSVUtils {
     static defaultConfig: CSVParseConfig = {
         header: false,
         dynamicTyping: false,
-        skipEmptyLines: false
+        skipEmptyLines: false,
+        quoteChar: '"'
     };
 
     /**


### PR DESCRIPTION
Fixes an issue where CSV files with commas inside quoted fields are parsed incorrectly, resulting in extra columns. The fix adds the PapaParse `quoteChar` option to the `CSVParseConfig` and `defaultConfig` in `CSVUtils`.

**Example content:**
```csv
Col 1, Col 2, Col 3
This, Should, "Be, Three, Columns"
```

**Before fix:**

| Col 1 | Col 2 | Col 3 | | |
| --- | --- | --- | --- | --- |
| This | Should | "Be | Three | Columns" |

**After fix:**

| Col 1 | Col 2 | Col 3 |
| --- | --- | --- |
| This | Should | Be, Three, Columns |