### PR TITLE
chore: bump version to 1.6.1 in manifest and package files and add zenodo doi badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple enough for csv, no more fancy function you need to learn and think!
 
 [中文版本 Readme](./README_zh.md)
 
-![Obsidian Download](https://img.shields.io/badge/dynamic/json?logo=obsidian&color=%23483699&label=Downloads&query=$%5B%22csv-lite%22%5D.downloads&url=https%3A%2F%2Fraw.githubusercontent.com%2Fobsidianmd%2Fobsidian-releases%2Fmaster%2Fcommunity-plugin-stats.json) ![Total Downloads](https://img.shields.io/github/downloads/LIUBINfighter/csv-lite/total?style=flat&label=Total%20Downloads) ![GitHub Issues](https://img.shields.io/github/issues/LIUBINfighter/csv-lite?style=flat&label=Issues) ![GitHub Last Commit](https://img.shields.io/github/last-commit/LIUBINfighter/csv-lite?style=flat&label=Last%20Commit)
+[![DOI](https://zenodo.org/badge/953422745.svg)](https://doi.org/10.5281/zenodo.18447042) ![Obsidian Download](https://img.shields.io/badge/dynamic/json?logo=obsidian&color=%23483699&label=Downloads&query=$%5B%22csv-lite%22%5D.downloads&url=https%3A%2F%2Fraw.githubusercontent.com%2Fobsidianmd%2Fobsidian-releases%2Fmaster%2Fcommunity-plugin-stats.json) ![Total Downloads](https://img.shields.io/github/downloads/LIUBINfighter/csv-lite/total?style=flat&label=Total%20Downloads) ![GitHub Issues](https://img.shields.io/github/issues/LIUBINfighter/csv-lite?style=flat&label=Issues) ![GitHub Last Commit](https://img.shields.io/github/last-commit/LIUBINfighter/csv-lite?style=flat&label=Last%20Commit)
 
 
 <!-- ![image](https://github.com/user-attachments/assets/6d956e79-4be7-4172-92e2-6f14ddba0dda) -->

--- a/README_zh.md
+++ b/README_zh.md
@@ -4,6 +4,8 @@
 
 [English Version Readme](./README.md)
 
+[![DOI](https://zenodo.org/badge/953422745.svg)](https://doi.org/10.5281/zenodo.18447042) ![Obsidian Download](https://img.shields.io/badge/dynamic/json?logo=obsidian&color=%23483699&label=Downloads&query=$%5B%22csv-lite%22%5D.downloads&url=https%3A%2F%2Fraw.githubusercontent.com%2Fobsidianmd%2Fobsidian-releases%2Fmaster%2Fcommunity-plugin-stats.json) ![Total Downloads](https://img.shields.io/github/downloads/LIUBINfighter/csv-lite/total?style=flat&label=Total%20Downloads) ![GitHub Issues](https://img.shields.io/github/issues/LIUBINfighter/csv-lite?style=flat&label=Issues) ![GitHub Last Commit](https://img.shields.io/github/last-commit/LIUBINfighter/csv-lite?style=flat&label=Last%20Commit)
+
 <!-- ![test-sample](./asssets/test-sample.png) -->
 <!-- ![v1.0.2 support searching](./asssets/searching.png) -->
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "csv-lite",
 	"name": "CSV Lite",
-	"version": "1.1.5",
+	"version": "1.6.1",
 	"minAppVersion": "1.8.0",
 	"description": "Just open and edit CSV files directly, no more. Keep it simple.",
 	"author": "Jay Bridge",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-csv",
-  "version": "1.1.5",
+  "version": "1.6.1",
   "description": "CSV viewer and editor for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
[![DOI](https://zenodo.org/badge/953422745.svg)](https://doi.org/10.5281/zenodo.18447042) ![Obsidian Download](https://img.shields.io/badge/dynamic/json?logo=obsidian&color=%23483699&label=Downloads&query=$%5B%22csv-lite%22%5D.downloads&url=https%3A%2F%2Fraw.githubusercontent.com%2Fobsidianmd%2Fobsidian-releases%2Fmaster%2Fcommunity-plugin-stats.json) ![Total Downloads](https://img.shields.io/github/downloads/LIUBINfighter/csv-lite/total?style=flat&label=Total%20Downloads) ![GitHub Issues](https://img.shields.io/github/issues/LIUBINfighter/csv-lite?style=flat&label=Issues) ![GitHub Last Commit](https://img.shields.io/github/last-commit/LIUBINfighter/csv-lite?style=flat&label=Last%20Commit)